### PR TITLE
Fixing the default fallback behavior for unknown keys

### DIFF
--- a/src/handlers/lib/discovery/DomainCatalog.js
+++ b/src/handlers/lib/discovery/DomainCatalog.js
@@ -1,12 +1,11 @@
 'use strict';
 
+const DefaultResolver = require('./resolvers/DefaultResolver');
 const EventsResolver = require('./resolvers/EventsResolver');
 
-class DomainCatalog {
-  constructor(defaultResolver) {
-    this.catalog = {
-      'default': defaultResolver,
-    };
+module.exports = class DomainCatalog {
+  constructor() {
+    this.catalog = {};
   }
 
   register(resolver) {
@@ -14,23 +13,21 @@ class DomainCatalog {
   }
 
   matchResolvers(entities) {
+    console.log(entities);
+    console.log(this.catalog);
     return entities.map((ent) => {
       return this.catalog[ent] || this.catalog['default'];
     });
   }
-};
-
-
-module.exports = {
-  DomainCatalog,
 
   setup() {
     const domainCatalog = new DomainCatalog();
+    domainCatalog.register(new DefaultResolver());
     domainCatalog.register(new EventsResolver());
     return domainCatalog;
-  },
+  }
 
-  getCatalog() {
-    return this.setup();
-  },
+  static getCatalog() {
+    return (new DomainCatalog()).setup();
+  }
 };

--- a/src/handlers/lib/discovery/resolvers/DefaultResolver.js
+++ b/src/handlers/lib/discovery/resolvers/DefaultResolver.js
@@ -26,6 +26,9 @@ module.exports = class DefaultResolver extends IResolverBase {
    * @return {Array}
    */
   resolve() {
-    return this.DATA;
+    console.log('Resolving default');
+    return new Promise((resolve, reject) => {
+      resolve(this.DATA);
+    });
   }
 };


### PR DESCRIPTION
Soo, before I have messed up with the setting up the resolver and have not properly implemented the default fallback mechanism... 
Now this fixes the problem and we get empty results array if we pass unknown keys. 

_Would be really nice to add testing_